### PR TITLE
Fix RisiBank API endpoint

### DIFF
--- a/src/services/RisibankClient.ts
+++ b/src/services/RisibankClient.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch'
 import {RisibankSearchRoot} from "../@types/risibank-client";
 
-const BASE_URL = 'https://api.risibank.fr/api/v0'
+const BASE_URL = 'https://risibank.fr/api/v0'
 
 export default new class RisibankClient {
 


### PR DESCRIPTION
Comme indiqué sur le site RisiBank, à partir du 1er Mars, il faudra accéder à l'API via `risibank.fr` et non plus `api.risibank.fr`

https://risibank.fr/doc-api
```text
Si vous utilisez le nom de domaine api.risibank.fr, merci de changer en risibank.fr.
Le nom de domaine api.risibank.fr sera supprimé le 1er Mars 2022.
```

Cette PR corrige simplement le nom de domaine utilisé dans le script
